### PR TITLE
Consistent naming

### DIFF
--- a/src/Commands/LaravelApiDiscovery.php
+++ b/src/Commands/LaravelApiDiscovery.php
@@ -3,7 +3,6 @@
 namespace LaravelApi\LaravelApi\Commands;
 
 use Illuminate\Console\Command;
-use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Http;
 use LaravelApi\LaravelApi\ManifestManager;
 

--- a/src/LaravelApi.php
+++ b/src/LaravelApi.php
@@ -4,30 +4,30 @@ namespace LaravelApi\LaravelApi;
 
 class LaravelApi
 {
-    protected $wrapper;
+    protected $apiWrapper;
 
-    public function __construct(protected $api)
+    public function __construct(protected $apiKey)
     {
-        $this->wrapper = $this->getWrapper();
+        $this->apiWrapper = $this->getApiWrapper();
     }
 
-    public function __call($name, $arguments)
+    public function __call(string $methodName, array $arguments)
     {
-        return $this->wrapper->$name(...$arguments);
+        return $this->apiWrapper->$methodName(...$arguments);
     }
 
     public function fake()
     {
-        return new ($this->getWrapper()->faker);
+        return new ($this->getApiWrapper()->faker);
     }
 
-    private function getWrapper()
+    private function getApiWrapper()
     {
-        return new ($this->getWrapperClassName());
+        return new ($this->getApiWrapperClassName());
     }
 
-    private function getWrapperClassName()
+    private function getApiWrapperClassName()
     {
-        return app(ManifestManager::class)->getManifest($this->api);
+        return app(ManifestManager::class)->getManifest($this->apiKey);
     }
 }

--- a/src/LaravelApiServiceProvider.php
+++ b/src/LaravelApiServiceProvider.php
@@ -3,7 +3,7 @@
 namespace LaravelApi\LaravelApi;
 
 use Illuminate\Support\Facades\File;
-use LaravelApi\LaravelApi\Commands\InstallApi;
+use LaravelApi\LaravelApi\Commands\InstallApiCommand;
 use LaravelApi\LaravelApi\Commands\LaravelApiDiscovery;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
@@ -20,13 +20,13 @@ class LaravelApiServiceProvider extends PackageServiceProvider
         $package
             ->name('laravel-api')
             ->hasCommand(LaravelApiDiscovery::class)
-            ->hasCommand(InstallApi::class);
+            ->hasCommand(InstallApiCommand::class);
 
         $this->registerManifestManager();
         $this->bootApis();
     }
 
-    private function registerManifestManager()
+    private function registerManifestManager(): void
     {
         $defaultManifestPath = $this->isRunningServerless()
             ? '/tmp/storage/bootstrap/cache/laravel-api-manifest.php'
@@ -37,11 +37,12 @@ class LaravelApiServiceProvider extends PackageServiceProvider
         });
     }
 
-    private function bootApis()
+    private function bootApis(): void
     {
-        collect(app(ManifestManager::class)->getManifest())
-            ->each(function($apiWrapperClass) {
-                $apiWrapper = (new $apiWrapperClass);
+        collect(app(ManifestManager::class)
+            ->getManifest())
+            ->each(function($apiWrapperClassName) {
+                $apiWrapper = (new $apiWrapperClassName);
 
                 foreach($apiWrapper->config() as $envKey => $config) {
                     config([$config['config'] => env($envKey)]);
@@ -53,7 +54,7 @@ class LaravelApiServiceProvider extends PackageServiceProvider
             });
     }
 
-    private function isRunningServerless()
+    private function isRunningServerless(): bool
     {
         return in_array($_ENV['SERVER_SOFTWARE'] ?? null, [
             'vapor',

--- a/src/ManifestManager.php
+++ b/src/ManifestManager.php
@@ -20,15 +20,15 @@ class ManifestManager
         return $api ? Arr::get($manifest, $api) : $manifest;
     }
 
-    public function putManifest(array $manifest)
+    public function putManifest(array $manifest): void
     {
         File::put($this->manifestPath, '<?php return ' . var_export($manifest, true) . ';', true);
     }
 
-    public function add($api, $definition)
+    public function add($apiKey, $apiWrapperClassName): void
     {
         $manifest = $this->getManifest();
-        $manifest[$api] = $definition;
+        $manifest[$apiKey] = $apiWrapperClassName;
         $this->putManifest($manifest);
     }
 }

--- a/src/ManifestManager.php
+++ b/src/ManifestManager.php
@@ -25,7 +25,7 @@ class ManifestManager
         File::put($this->manifestPath, '<?php return ' . var_export($manifest, true) . ';', true);
     }
 
-    public function add($apiKey, $apiWrapperClassName): void
+    public function add(string $apiKey, string $apiWrapperClassName): void
     {
         $manifest = $this->getManifest();
         $manifest[$apiKey] = $apiWrapperClassName;

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -1,8 +1,8 @@
 <?php
 
 if (! function_exists('api')) {
-    function api($api)
+    function api(string $apiKey)
     {
-        return new LaravelApi\LaravelApi\LaravelApi($api);
+        return new LaravelApi\LaravelApi\LaravelApi($apiKey);
     }
 }


### PR DESCRIPTION
Dieser PR ist ein Vorschlag für eine einheitliche Be-Namung:


* `twitter`    ist ein   --> `apiKey`
* `unsere Wrapper`  --> `apiWrapper`
* `Klassen Namen` --> `className eg. apiWrapperClassName`

Ich hab auch Types hinzugefügt, ich hoffe das stört dich nicht?

Was fehlt noch:

* In der API gibt es noch `Definition`, das finde ich nicht sehr aussagekräftig, eigentlich wäre das auch `apiWrapperClassName`?
* Mit "fake" und "faker" bin ich noch nicht happy für die test responses, ich möchte nicht dass es verwirrt wenn der der Befehl zum faken für Tests auch `::fake()` heißt.